### PR TITLE
fix: add platformio.ini to spell check ignore list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,7 +6,8 @@
     "**/.git/**",
     "**/.github/**",
     "**/.gitignore",
-    "**/.vscode/**"
+    "**/.vscode/**",
+    "**/platformio.ini"
   ],
   "ignoreRegExpList": [
     "Copyright .*[0-9]{4}.+"


### PR DESCRIPTION
platformio.iniをスペルチェックの対象から除外する。